### PR TITLE
Feat/presigned download ticket

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Ignore node_modules
+**/node_modules
+node_modules
+client/node_modules
+cloudflare/node_modules
+cloudflare/workers/node_modules
+
+# Ignore build artifacts and outputs
+**/dist
+**/dist-bin
+dist
+dist-bin
+client/dist
+
+# Ignore version control and system files
+.git
+.github
+.gitignore
+.dockerignore
+.DS_Store
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,21 @@ cloudflare/node_modules
 clipboard-monitor
 clipboard-monitor/src-tauri/target/
 openwrt/build/
+
+# Build artifacts & binaries output
+/dist/
+/dist-bin/
+**/dist/
+**/dist-bin/
+
+# Dependencies
+node_modules/
+**/node_modules/
+
+# Root level accidental package-lock
+/package-lock.json
+
+# OS & Environment junk files
+.DS_Store
+**/.DS_Store
+*.log

--- a/client/src/components/received-item/File.vue
+++ b/client/src/components/received-item/File.vue
@@ -65,8 +65,7 @@
                                         icon
                                         color="grey"
                                         class="timeline-card__icon-button"
-                                        :href="expired ? null : fileUrl"
-                                        :download="expired ? null : meta.name"
+                                        @click="!expired && downloadWithTicket()"
                                         :disabled="expired"
                                     >
                                         <v-icon>{{ expired ? mdiDownloadOff : mdiDownload }}</v-icon>
@@ -312,6 +311,42 @@ export default {
             }
             return url.toString();
         },
+        downloadWithTicket() {
+            const cache = this.meta?.cache || '';
+            const roomQuery = this.$root.room ? `?room=${this.$root.room}` : '';
+            this.$http.post(`ticket/${cache}${roomQuery}`).then(response => {
+                const ticket = response.data?.ticket;
+                const encodedFilename = encodeURIComponent(this.meta?.name || 'file');
+                const prefix = this.$root.config?.server?.prefix || '';
+                const baseURL = this.$http?.defaults?.baseURL || '';
+                
+                let targetUrl = '';
+                if (baseURL) {
+                    targetUrl = `${baseURL.replace(/\/+$/, '')}/file/${cache}/${encodedFilename}`;
+                } else {
+                    targetUrl = `${window.location.origin}${prefix}/file/${cache}/${encodedFilename}`;
+                }
+
+                const urlObj = new URL(targetUrl);
+                if (ticket) {
+                    urlObj.searchParams.set('auth', ticket);
+                }
+                urlObj.searchParams.set('download', 'true');
+                
+                const link = document.createElement('a');
+                link.href = urlObj.toString();
+                link.setAttribute('download', this.meta?.name || 'file');
+                document.body.appendChild(link);
+                link.click();
+                link.remove();
+            }).catch(error => {
+                if (error.response && error.response.data && error.response.data.message) {
+                    this.$toast(error.response.data.message);
+                } else {
+                    this.$toast(this.$t('fileFetchFailed'));
+                }
+            });
+        },
         previewFile() {
             if (this.expand) {
                 this.expand = false;
@@ -322,7 +357,27 @@ export default {
             }
             this.expand = true;
             if (this.isPreviewableVideo || this.isPreviewableAudio) {
-                this.srcPreview = this.fileUrl;
+                const cache = this.meta?.cache || '';
+                const roomQuery = this.$root.room ? `?room=${this.$root.room}` : '';
+                this.loadingPreview = true;
+                this.$http.post(`ticket/${cache}${roomQuery}`).then(response => {
+                    const ticket = response.data?.ticket;
+                    const encodedFilename = encodeURIComponent(this.meta?.name || 'file');
+                    const prefix = this.$root.config?.server?.prefix || '';
+                    const baseURL = this.$http?.defaults?.baseURL || '';
+                    let targetUrl = baseURL
+                        ? `${baseURL.replace(/\/+$/, '')}/file/${cache}/${encodedFilename}`
+                        : `${window.location.origin}${prefix}/file/${cache}/${encodedFilename}`;
+                    const urlObj = new URL(targetUrl);
+                    if (ticket) {
+                        urlObj.searchParams.set('auth', ticket);
+                    }
+                    this.srcPreview = urlObj.toString();
+                }).catch(() => {
+                    this.srcPreview = this.fileUrl;
+                }).finally(() => {
+                    this.loadingPreview = false;
+                });
             } else if (this.isPreviewableText) {
                 this.showFullTextPreview = false;
                 this.loadingPreview = true;

--- a/cloud-clip/Dockerfile
+++ b/cloud-clip/Dockerfile
@@ -1,21 +1,29 @@
 # 前端构建阶段
 FROM node:22.12-alpine3.21 AS frontend
 ENV NODE_OPTIONS=--openssl-legacy-provider
-COPY client /app
 WORKDIR /app
-RUN npm install
+
+# 优先复制 package*.json 利用层缓存
+COPY client/package*.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci || npm install
+
+# 复制前端源码并构建
+COPY client/ ./
+RUN chmod +x node_modules/.bin/* 2>/dev/null || true
 RUN npm run build
 
 # 后端构建阶段
 FROM golang:1.23-alpine AS builder
 
-# 设置工作目录
 WORKDIR /app
-# 复制 Go 模块文件（确保这些文件在 cloud-clip 目录下）
-COPY cloud-clip/go.mod cloud-clip/go.sum ./
-RUN go mod download
 
-# 复制源代码
+# 优先复制 Go 模块依赖文件利用层缓存
+COPY cloud-clip/go.mod cloud-clip/go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+# 复制 Go 源码
 COPY cloud-clip/ ./
 
 # 创建静态文件目录
@@ -24,24 +32,26 @@ RUN mkdir -p lib/static
 # 复制前端构建结果
 COPY --from=frontend /app/dist lib/static/
 
-# 编译应用，启用嵌入式静态文件
-RUN CGO_ENABLED=0 GOOS=linux go build -tags=embed -ldflags="-s -w" -o cloud-clipboard-go .
+# 编译应用，启用 Go 编译缓存与 Go module 缓存
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux go build -tags=embed -ldflags="-s -w" -o cloud-clipboard-go .
 
 # 最终镜像
 FROM alpine:latest
 
 # 安装运行时依赖
-RUN apk add --no-cache ca-certificates netcat-openbsd
+RUN apk add --no-cache ca-certificates netcat-openbsd git tzdata \
+    && apk add --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing mkcert
 
 # 创建应用目录
 WORKDIR /app/server-node
 
-# 从构建阶段复制编译好的应用
+# 从构建阶段复制编译好的应用与启动脚本
 COPY --from=builder /app/cloud-clipboard-go .
 COPY cloud-clip/entrypoint.sh /app/
-RUN apk add --no-cache git tzdata \
-    && chmod +x /app/entrypoint.sh \
-    && apk add --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing mkcert
+RUN chmod +x /app/entrypoint.sh
+
 # 暴露端口
 EXPOSE 9501
 

--- a/cloud-clip/Dockerfile.dockerignore
+++ b/cloud-clip/Dockerfile.dockerignore
@@ -1,0 +1,21 @@
+# Ignore node_modules
+**/node_modules
+node_modules
+client/node_modules
+cloudflare/node_modules
+cloudflare/workers/node_modules
+
+# Ignore build artifacts and outputs
+**/dist
+**/dist-bin
+dist
+dist-bin
+client/dist
+
+# Ignore version control and system files
+.git
+.github
+.gitignore
+.dockerignore
+.DS_Store
+*.log

--- a/cloud-clip/lib/auth.go
+++ b/cloud-clip/lib/auth.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type RoomAuthRequirement struct {
@@ -127,10 +128,63 @@ func (s *ClipboardServer) tokenMatchesRoom(room string, token string) bool {
 
 	normalizedRoom := normalizeRoomName(room)
 	if roomPassword, ok := s.config.Server.RoomAuth[normalizedRoom]; ok && roomPassword != "" {
-		return token == roomPassword
+		if token == roomPassword {
+			return true
+		}
 	}
 
 	return false
+}
+
+// createDownloadTicket 为指定文件生成短期有效的下载 Ticket (默认60秒有效)
+func (s *ClipboardServer) createDownloadTicket(uuid string, room string) string {
+	s.ticketMutex.Lock()
+	defer s.ticketMutex.Unlock()
+
+	ticket := gen_UUID()
+	now := time.Now().Unix()
+
+	// 顺便清理过期的 ticket
+	for t, dt := range s.downloadTicketMap {
+		if dt.ExpireTime < now {
+			delete(s.downloadTicketMap, t)
+		}
+	}
+
+	s.downloadTicketMap[ticket] = DownloadTicket{
+		Ticket:     ticket,
+		UUID:       uuid,
+		Room:       normalizeRoomName(room),
+		ExpireTime: now + 60, // 60秒有效
+	}
+
+	return ticket
+}
+
+// validateAndConsumeTicket 验证 Ticket 是否有效且匹配目标文件 UUID，并在验证成功后一次性销毁 (Single-use)
+func (s *ClipboardServer) validateAndConsumeTicket(ticket string, targetUUID string) bool {
+	s.ticketMutex.Lock()
+	defer s.ticketMutex.Unlock()
+
+	dt, ok := s.downloadTicketMap[ticket]
+	if !ok {
+		return false
+	}
+
+	now := time.Now().Unix()
+	if dt.ExpireTime < now {
+		delete(s.downloadTicketMap, ticket)
+		return false
+	}
+
+	if dt.UUID != "" && targetUUID != "" && dt.UUID != targetUUID {
+		return false
+	}
+
+	// 消费凭证（一次性使用）
+	delete(s.downloadTicketMap, ticket)
+
+	return true
 }
 
 func (s *ClipboardServer) canAccessRoom(room string, token string) bool {

--- a/cloud-clip/lib/handler.go
+++ b/cloud-clip/lib/handler.go
@@ -235,6 +235,28 @@ func (s *ClipboardServer) handle_push(w http.ResponseWriter, r *http.Request) {
 	}()
 }
 
+func (s *ClipboardServer) handle_ticket(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "仅允许 POST 请求", http.StatusMethodNotAllowed)
+		return
+	}
+
+	pathPart := strings.TrimPrefix(r.URL.Path, s.config.Server.Prefix+"/ticket/")
+	uuid := strings.SplitN(pathPart, "/", 2)[0]
+	if uuid == "" {
+		http.Error(w, "无效的 UUID", http.StatusBadRequest)
+		return
+	}
+
+	room := s.inferRequestRoom(r)
+	ticket := s.createDownloadTicket(uuid, room)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"ticket": ticket,
+	})
+}
+
 func (s *ClipboardServer) handle_file(w http.ResponseWriter, r *http.Request) {
 	// 修改 UUID 提取逻辑
 	pathPart := strings.TrimPrefix(r.URL.Path, s.config.Server.Prefix+"/file/")

--- a/cloud-clip/lib/main.go
+++ b/cloud-clip/lib/main.go
@@ -134,8 +134,9 @@ func NewClipboardServer(cfg *Config) (*ClipboardServer, error) {
 		deviceHashSeed:  murmur3.Sum32(random_bytes(32)) & 0xffffffff, // 在此处初始化种子
 
 		// 初始化房间管理相关字段
-		roomStats:      make(map[string]*RoomStat),
-		roomStatsMutex: sync.RWMutex{},
+		roomStats:         make(map[string]*RoomStat),
+		roomStatsMutex:    sync.RWMutex{},
+		downloadTicketMap: make(map[string]DownloadTicket),
 	}
 
 	if err := s.loadHistoryData(); err != nil {
@@ -314,6 +315,7 @@ func (s *ClipboardServer) setupRoutes() {
 	mux.HandleFunc(prefix+"/server", s.handle_server)
 	mux.HandleFunc(prefix+"/push", s.handle_push)
 	mux.HandleFunc(prefix+"/rooms", s.handleRooms)
+	mux.HandleFunc(prefix+"/ticket/", s.authMiddleware(s.handle_ticket))
 	mux.HandleFunc(prefix+"/file/", s.authMiddleware(s.handle_file))
 	mux.HandleFunc(prefix+"/text", s.authMiddleware(s.handle_text))
 	mux.HandleFunc(prefix+"/upload", s.authMiddleware(s.handle_upload))
@@ -666,15 +668,26 @@ func (s *ClipboardServer) authMiddleware(next http.HandlerFunc) http.HandlerFunc
 			return
 		}
 
+		token := extractAuthToken(r)
+		clientIP := get_remote_ip(r)
+
+		// 优先校验临时下载 Ticket
+		filePrefix := s.config.Server.Prefix + "/file/"
+		if strings.HasPrefix(r.URL.Path, filePrefix) && token != "" {
+			pathPart := strings.TrimPrefix(r.URL.Path, filePrefix)
+			uuid := strings.SplitN(pathPart, "/", 2)[0]
+			if s.validateAndConsumeTicket(token, uuid) {
+				s.logger.Printf("Ticket 认证成功: IP: %s, 路径: %s, UUID: %s", clientIP, r.URL.Path, uuid)
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+
 		requirement := s.resolveRoomAuth(s.inferRequestRoom(r))
 		if !requirement.Required {
 			next.ServeHTTP(w, r)
 			return
 		}
-
-		token := extractAuthToken(r)
-
-		clientIP := get_remote_ip(r)
 
 		// 验证令牌
 		if token == "" {

--- a/cloud-clip/lib/type.go
+++ b/cloud-clip/lib/type.go
@@ -78,6 +78,17 @@ type ClipboardServer struct {
 	roomStats         map[string]*RoomStat `json:"-"` // 房间统计信息，不序列化
 	roomStatsMutex    sync.RWMutex         `json:"-"` // 房间统计读写锁
 	roomCleanupTicker *time.Ticker         `json:"-"` // 房间清理定时器
+
+	// 临时下载凭证 (Ticket)
+	downloadTicketMap map[string]DownloadTicket `json:"-"`
+	ticketMutex       sync.Mutex                `json:"-"`
+}
+
+type DownloadTicket struct {
+	Ticket     string
+	UUID       string
+	Room       string
+	ExpireTime int64
 }
 
 // file item in File[]

--- a/extract-binary.sh
+++ b/extract-binary.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="${1:-}"
+OUTPUT_DIR="${2:-./dist-bin}"
+CONTAINER_BINARY_PATH="/app/server-node/cloud-clipboard-go"
+
+# 检查 Docker 命令
+if ! command -v docker &> /dev/null; then
+    echo "错误: 系统中未找到 docker 命令！" >&2
+    exit 1
+fi
+
+# 如果未提供镜像名称参数，默认从源码构建最新的 Docker 镜像
+if [ -z "${IMAGE_NAME}" ]; then
+    IMAGE_NAME="cloud-clipboard-go:build-tmp"
+    echo "==> 未指定镜像名称，正在从当前源码构建最新 Docker 镜像 (${IMAGE_NAME})..."
+    DOCKER_BUILDKIT=1 docker build -f cloud-clip/Dockerfile -t "${IMAGE_NAME}" .
+else
+    echo "==> 使用指定的镜像: ${IMAGE_NAME}"
+fi
+
+echo "==> 输出目录: ${OUTPUT_DIR}"
+mkdir -p "${OUTPUT_DIR}"
+
+CONTAINER_ID=""
+
+# 确保脚本退出时清理临时容器
+cleanup() {
+    if [ -n "${CONTAINER_ID:-}" ]; then
+        docker rm -f "${CONTAINER_ID}" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+# 创建临时容器（不运行）
+CONTAINER_ID=$(docker create "${IMAGE_NAME}")
+
+# 从容器中拷贝编译好的二进制文件
+echo "==> 正在提取二进制文件..."
+docker cp "${CONTAINER_ID}:${CONTAINER_BINARY_PATH}" "${OUTPUT_DIR}/cloud-clipboard-go"
+
+chmod +x "${OUTPUT_DIR}/cloud-clipboard-go"
+
+echo "==> 成功提取二进制文件到: ${OUTPUT_DIR}/cloud-clipboard-go"
+ls -lh "${OUTPUT_DIR}/cloud-clipboard-go"


### PR DESCRIPTION
    ## Summary of Changes

    ### 1. Security & Auth (`feat(auth)`)
    - Introduced single-use presigned download tickets (`ticket` parameter) for secure file & media downloads without exposing ambient credentials or session cookies.
    - Added client-side ticket request and attachment flow on file download actions.

    ### 2. Docker & Build Infrastructure (`build(docker)`)
    - **Layer Caching**: Reordered `go.mod`/`go.sum` and `package*.json` copy instructions in `cloud-clip/Dockerfile` to maximize Docker build layer caching.
    - **Context Exclusion**: Added `.dockerignore` and `cloud-clip/Dockerfile.dockerignore` to prevent local `node_modules`, `dist`, and OS temporary files (`.DS_Store`) from leaking into the container context (resolving build-time permission  issues).
    - **Binary Extraction Utility**: Added `extract-binary.sh` script for building and extracting binary artifacts directly from Docker containers.
    - **Cleanup**: Removed stray root `package-lock.json` and `.DS_Store` files from version tracking.


    ## 📝 概述 (Overview)

    本 PR 主要带来了以下改进：
    1. **安全文件与媒体下载机制 (Presigned Single-Use Download Tickets)**：解决了开启 `server.auth` 或 `roomAuth` 密码认证时，浏览器原生下载无法带 `Authorization` Header 导致 401 失败的问题。
    2. **Docker 构建缓存优化与提取脚本**：提升前端/后端 Docker 镜像二次构建速度，并添加可快速从镜像提取二进制文件的工具脚本。

    ---

    ## 🔒 1. 临时下载凭证 (Presigned Download Ticket)

    ### 背景与痛点
    当配置了密码/Token 认证时，用户在前端点击下载触发的是原生 `<a href="...">` 浏览器跳转。浏览器原生下载不经过 Axios，无法自动附带 `Authorization` 请求头。若将长期 Token 拼接到 URL 框中，会存在密码暴露在日志、地址栏及历史记录中的安全隐患。

    ### 解决方案
    采用类似 AWS S3 Presigned URL / 临时 Ticket 机制：
    1. **安全换票**：前端点击下载/预览时，先通过 Axios 发起 `POST /ticket/{uuid}?room=xxx`（带有 Header 鉴权）。
    2. **短期凭证**：后端在内存中签发一个 60s 有效的 UUID Ticket。
    3. **单次使用销毁 (Single-use)**：前端使用 `GET /file/{uuid}/{filename}?auth={ticket}&download=true` 触发原生下载，后端验证通过后**立即销毁该 Ticket**，彻底规避凭证重放攻击 (Replay Attack)。
    4. **媒体预览覆盖**：在音频/视频预览时同步应用该 Ticket 机制，保证媒体播放器流式播放安全顺畅。

    ---

    ## ⚡ 2. Docker 构建优化 (Docker Caching & Tooling)

    1. **依赖层缓存 (Layer Caching)**：在 `cloud-clip/Dockerfile` 中优先拷贝 `package*.json` 与 `go.mod/go.sum` 进行依赖安装，使源码修改时无需重新下载 node_modules 和 go modules。
    2. **BuildKit 缓存挂载**：引入 `--mount=type=cache` 缓存 npm 与 Go build 编译中间件，实现极速增量构建。
    3. **二进制提取脚本 (`extract-binary.sh`)**：支持一键从源码构建并提取纯静音态二进制文件到 `dist-bin/cloud-clipboard-go`。

    ---

    ## ✅ 测试与验证 (Verification)

    - [x] 本地 Go 编译与测试通过 (`go build ./...` / `go test ./...`)。
    - [x] Docker 镜像构建测试成功。
    - [x] 带全局密码/房间密码环境下测试 Edge/Chrome 点击下载，文件正常下载且验证凭证单次消费有效。